### PR TITLE
Abbreviate journal if requested and if possible

### DIFF
--- a/doi2bib/crossref.py
+++ b/doi2bib/crossref.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, print_function, absolute_import
 from builtins import str
 import requests
+import re
 
 bare_url = "http://api.crossref.org/"
 
@@ -30,7 +31,12 @@ def get_bib_from_doi(doi, abbrev_journal=False):
 
         found, item = get_json(doi)#json vindo errado
         if found:
-            abbreviated_journal = item["message"]["short-container-title"][0]
+            abbreviated_journal = item["message"]["short-container-title"][0].strip()
+            if abbreviated_journal:
+                bib = re.sub(
+                    r"journal = \{[^>]*?\}",
+                    "journal = {" + abbreviated_journal + "}",
+                    bib)
         #pegar journal contraido e contrair autores
         # depois fazer um replace no bib com  o nome do journal e o
         #contraido, ou usar o bibtexparser(ultima melhor)


### PR DESCRIPTION
This seems to work. The journal was abbreviated here, for example (if I pass in 'True' for the second argument to get_bib_from_doi() in doi2bib):

```
$ doi2bib 10.1103/physrevmaterials.1.014602



@article{Eifert_2017,
	doi = {10.1103/physrevmaterials.1.014602},
	url = {https://doi.org/10.1103%2Fphysrevmaterials.1.014602},
	year = 2017,
	month = {jun},
	publisher = {American Physical Society ({APS})},
	volume = {1},
	number = {1},
	author = {Bianca Eifert and Martin Becker and Christian T. Reindl and Marcel Giar and Lilan Zheng and Angelika Polity and Yunbin He and Christian Heiliger and Peter J. Klar},
	title = {Raman studies of the intermediate tin-oxide phase},
	journal = {Phys. Rev. Materials}
}
```